### PR TITLE
HGI-7377 - Set falsy date fields to null on Fallback sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode

--- a/target_salesforce_v3/sinks.py
+++ b/target_salesforce_v3/sinks.py
@@ -893,9 +893,10 @@ class FallbackSink(SalesforceV3Sink):
         # keep only available fields and that are creatable or updatable
         # NOTE: we need to keep relations (__r, xId)
         record = {k:v for k,v in record.items() if k.endswith("__r") or fields.get(k+"Id") or (fields.get(k) and (fields[k]["createable"] or fields[k]["updateable"] or k.lower() in ["id", "externalid"]))}
-        # clean empty date fields to avoid salesforce parsing error
-        record = {k:v for k,v in record.items() if fields.get(k, {}).get("type") not in ["date", "datetime"] or (fields.get(k, {}).get("type") in ["date", "datetime"] and v)}
         
+        # set falsy date fields to None so they are nullified properly in Salesforce
+        record = {k: None if (not v and fields.get(k, {}).get("type") in ["date", "datetime"]) else v for k,v in record.items()}
+
         # add object_type
         record["object_type"] = object_type
 


### PR DESCRIPTION
Currently the fallback sink pops all falsy date fields from the record. This was originally done to avoid an error that occurs when passing empty strings to a date field.

This PR changes the Fallback sink so that all falsy date values map to Null, which will nullify the existing field in salesforce. For context, this is already the case for all other fields.