### PR TITLE
Raise InvalidPayloadError for duplicate values to enable hg_error_class filtering

### DIFF
--- a/target_salesforce_v3/sinks.py
+++ b/target_salesforce_v3/sinks.py
@@ -1301,7 +1301,7 @@ class FallbackSink(SalesforceV3Sink):
             if patch_errors:
                 self.logger.error(f"Error(s) while updating record: {patch_errors}")
             if "duplicate" in str(e) and patch_errors:
-                return None, False, {"errors": f"failed during updating record, patch errors by externalId field {patch_errors}"}
+                raise InvalidPayloadError(f"failed during updating record, patch errors by externalId field {patch_errors}")
             
             self.logger.exception(f"Error encountered while creating {object_type}")
             raise e


### PR DESCRIPTION
When a Salesforce upsert fails due to a DUPLICATE_VALUE error, the target now raises an InvalidPayloadError instead of `return None` failure, ensuring the error is properly classified with hg_error_class in the target state so the alerting system can handle it correctly.