### PR TITLE
fix: add ConnectionError & ConnectionResetError to retryable exception

### DIFF
--- a/target_salesforce_v3/client.py
+++ b/target_salesforce_v3/client.py
@@ -154,7 +154,7 @@ class SalesforceV3Sink(HotglueSink, RecordSink):
 
     @backoff.on_exception(
         backoff.expo,
-        (RetriableAPIError, requests.exceptions.ReadTimeout),
+        (RetriableAPIError, requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError, ConnectionResetError),
         max_tries=8,
         factor=3,
     )


### PR DESCRIPTION

- Added ConnectionResetError to handle TCP connection resets (Errno 104)
- Added requests.exceptions.ConnectionError for other network failures