### PR TITLE
HGI-10564 | Raise InvalidPayloadError when Invalid_field_for_insert_update

### DIFF
--- a/target_salesforce_v3/sinks.py
+++ b/target_salesforce_v3/sinks.py
@@ -1326,7 +1326,9 @@ class FallbackSink(SalesforceV3Sink):
                 try:
                     fields = json.loads(str(e))[0]['fields']
                 except:
-                    raise e
+                    raise InvalidPayloadError(
+                        f"Attempted to write read-only fields. Unable to extract read-only fields to retry request: {str(e)}"
+                    )
                 
                 self.logger.warning(f"Attempted to write read-only fields: {fields}. Removing them and retrying.")
                 # append read-only field to a list

--- a/target_salesforce_v3/sinks.py
+++ b/target_salesforce_v3/sinks.py
@@ -1326,7 +1326,7 @@ class FallbackSink(SalesforceV3Sink):
                 try:
                     fields = json.loads(str(e))[0]['fields']
                 except:
-                    raise Exception(f"Attempted to write read-only fields. Unable to extract read-only fields to retry request: {str(e)}")
+                    raise e
                 
                 self.logger.warning(f"Attempted to write read-only fields: {fields}. Removing them and retrying.")
                 # append read-only field to a list

--- a/tests/test_fallback_sink.py
+++ b/tests/test_fallback_sink.py
@@ -7,7 +7,7 @@ from hotglue_etl_exceptions import InvalidPayloadError
 from target_salesforce_v3.sinks import FallbackSink
 
 
-def test_fallback_sink_preserves_invalid_payload_error_for_account_create_failure():
+def test_fallback_sink_raises_invalid_payload_error_for_account_create_failure():
     sink = FallbackSink.__new__(FallbackSink)
     sink.logger = Mock()
     sink.stream_name = "Account"
@@ -22,9 +22,12 @@ def test_fallback_sink_preserves_invalid_payload_error_for_account_create_failur
         "external_ids": [],
         "pickable": {},
     })
-    sink.request_api = Mock(side_effect=InvalidPayloadError("INVALID_FIELD_FOR_INSERT_UPDATE: Name"))
+    sink.request_api = Mock(side_effect=Exception("INVALID_FIELD_FOR_INSERT_UPDATE: Name"))
     sink.link_attachment_to_object = Mock()
     sink._handle_person_account = Mock()
 
-    with pytest.raises(InvalidPayloadError, match="INVALID_FIELD_FOR_INSERT_UPDATE: Name"):
+    with pytest.raises(
+        InvalidPayloadError,
+        match="Attempted to write read-only fields. Unable to extract read-only fields to retry request: INVALID_FIELD_FOR_INSERT_UPDATE: Name",
+    ):
         sink.upsert_record({"object_type": "Account", "Name": "Invalid"}, context={})

--- a/tests/test_fallback_sink.py
+++ b/tests/test_fallback_sink.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from hotglue_etl_exceptions import InvalidPayloadError
+
+from target_salesforce_v3.sinks import FallbackSink
+
+
+def test_fallback_sink_preserves_invalid_payload_error_for_account_create_failure():
+    sink = FallbackSink.__new__(FallbackSink)
+    sink.logger = Mock()
+    sink.stream_name = "Account"
+    sink.name = "Account"
+    sink.config = {}
+    sink.key_properties = []
+    sink._target = SimpleNamespace(read_only_fields={})
+    sink.sf_fields_description = Mock(return_value={
+        "createable": ["Name"],
+        "custom": [],
+        "required": [],
+        "external_ids": [],
+        "pickable": {},
+    })
+    sink.request_api = Mock(side_effect=InvalidPayloadError("INVALID_FIELD_FOR_INSERT_UPDATE: Name"))
+    sink.link_attachment_to_object = Mock()
+    sink._handle_person_account = Mock()
+
+    with pytest.raises(InvalidPayloadError, match="INVALID_FIELD_FOR_INSERT_UPDATE: Name"):
+        sink.upsert_record({"object_type": "Account", "Name": "Invalid"}, context={})


### PR DESCRIPTION
This keeps the Account write failure path from replacing an invalid payload condition with a generic exception when the `INVALID_FIELD_FOR_INSERT_UPDATE` message is not JSON.

Changes:
- raise `InvalidPayloadError` with the existing read-only-fields failure message when the fallback sink cannot extract retryable fields from the error payload
- add a focused regression test covering an Account create failure that surfaces `INVALID_FIELD_FOR_INSERT_UPDATE`

Verification:
- not run in this environment (`python`, `pytest`, and `poetry` are not installed on PATH)